### PR TITLE
add keywords to package.json so it can be easier found on npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "mocha-tnv",
   "version": "1.3.6",
   "description": "mocha test envirnoment tools",
+  "keywords": [
+    "mocha",
+    "parallel"
+  ],
   "dependencies": {
     "async": "1.4.0",
     "lodash": "3.10.0",


### PR DESCRIPTION
currently: if you search for mocha parallel on npmjs you dont find this module.
keywords will help :)
